### PR TITLE
build!: Bump to 4.0.0-SN and use jahia-authentication 2.0.0-SN

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ JCR Auth Provider
 This module works with Jahia Authentication and allows you to create(if needed) and connect an user as a result of an open authentication.
 
 ### MINIMAL REQUIREMENTS
-* Jahia 8.0.1.0
-* Jahia Authentication module 1.0.0
+* Jahia 8.2.3.0 or higher
+* Jahia Authentication module 2.0.0
 * At least one connector module
 
 ### INSTALLATION

--- a/pom.xml
+++ b/pom.xml
@@ -49,11 +49,11 @@
     <parent>
         <groupId>org.jahia.modules</groupId>
         <artifactId>jahia-modules</artifactId>
-        <version>8.1.2.0</version>
+        <version>8.2.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jcr-auth-provider</artifactId>
-    <version>3.5.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>JCR Authentication provider</name>
     <description>This is the custom module (JCR Auth provider) for running on a Digital Experience Manager server.
@@ -67,9 +67,8 @@
     </scm>
 
     <properties>
-        <jahia.plugin.version>6.9</jahia.plugin.version>
         <jahia-depends>jahia-authentication</jahia-depends>
-        <jahia-module-signature>MCwCFFpnRDPTwoJq1btYk1QDBG3y+7F/AhQ0oCRIH1udJmCJVMRmWMOGclCKiQ==</jahia-module-signature>
+        <jahia-module-signature>MC0CFGyoZM43PHWTj0NWEOf3V7xWWzn5AhUAkg3R05sotRuedCoI2leebiXxeI0=</jahia-module-signature>
     </properties>
 
     <distributionManagement>
@@ -128,7 +127,7 @@
         <dependency>
             <groupId>org.jahia.modules</groupId>
             <artifactId>jahia-authentication</artifactId>
-            <version>1.0.0</version>
+            <version>2.0.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Closes https://github.com/Jahia/jahia-oauth/issues/120.
### Description
Bump the module version to 4.0.0-SNAPSHOT that uses the new jahia-authentication in version 2.0.0-SNAPSHOT (see https://github.com/Jahia/jahia-authentication/pull/76).
This is needed so that the nightly tests of jahia-oauth can run, see https://github.com/Jahia/jahia-oauth/pull/119. 


> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
