### PR TITLE
feat: do not overwrite configuration file on module deployment

### DIFF
--- a/.chachalog/z3M1U1GX.md
+++ b/.chachalog/z3M1U1GX.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+jcr-auth-provider: minor
+---
+
+Change configuration file behaviour to allow custom modification (#72)

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <parent>
         <groupId>org.jahia.modules</groupId>
         <artifactId>jahia-modules</artifactId>
-        <version>8.2.3.0-SNAPSHOT</version>
+        <version>8.2.3.0</version>
     </parent>
 
     <artifactId>jcr-auth-provider</artifactId>

--- a/src/main/resources/META-INF/configurations/org.jahia.modules.jcroauthprovider.impl.JCROAuthProviderMapperImpl.cfg
+++ b/src/main/resources/META-INF/configurations/org.jahia.modules.jcroauthprovider.impl.JCROAuthProviderMapperImpl.cfg
@@ -1,3 +1,4 @@
+# default configuration - won't be overriden
 mapperServiceName=jcrOAuthProvider
 # Defines the list of mapping (comma separated), by default the type is "string", to set another type, please use the following syntaxt property|type, for example j:income|long
 mappings=ssoLoginId,j:title,j:firstName,j:lastName,j:gender,j:email|email,j:organization,j:function,\


### PR DESCRIPTION
### Description
This pull request change the behaviour of the configuration file of the module.

Configuration additions:

* Added  `# default configuration - won't be overriden` in top of`org.jahia.modules.jcroauthprovider.impl.JCROAuthProviderMapperImpl.cfg` file to allow customer to customise this configuration.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
