### PR TITLE
fix: load i18n translations using urlrewrite

### DIFF
--- a/.chachalog/rjWLsNNd.md
+++ b/.chachalog/rjWLsNNd.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+jcr-auth-provider: patch
+---
+
+Fixed an issue causing part of the module to not be refreshed when installing new versions (#86)

--- a/src/main/resources/META-INF/urlrewrite-jcr-auth-provider.xml
+++ b/src/main/resources/META-INF/urlrewrite-jcr-auth-provider.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE urlrewrite PUBLIC "-//tuckey.org//DTD UrlRewrite 3.2//EN"
+        "http://tuckey.org/res/dtds/urlrewrite3.2.dtd">
+
+<urlrewrite>
+
+    <rule>
+        <name>i18n resources (inbound)</name>
+        <note>Handles checksum for the resources of the i18n js bundles for the proper cache support</note>
+        <from>^/modules/(.*)/javascript/i18n/(.*)\.v[0-9a-f]+\.js</from>
+        <to last="true">/modules/$1/javascript/i18n/$2.js</to>
+    </rule>
+
+    <outbound-rule>
+        <name>i18n resources (outbound)</name>
+        <note>Handles checksum for the resources of the i18n js bundle for the proper cache support</note>
+        <from>^(/[\p{Alnum}\-_]*)?(/modules/(.*)/javascript/i18n/(.*)\.js)$</from>
+        <run class="org.jahia.services.seo.urlrewrite.ResourceChecksumCalculator" method="calculateChecksum(HttpServletRequest, String, String)"/>
+        <to last="true" encode="false">$1/modules/$3/javascript/i18n/$4.v%{attribute:ResourceChecksumCalculator.checksum}.js</to>
+    </outbound-rule>
+
+</urlrewrite>

--- a/src/main/resources/joant_jcrOAuthView/html/jcrOAuthView.jsp
+++ b/src/main/resources/joant_jcrOAuthView/html/jcrOAuthView.jsp
@@ -17,12 +17,14 @@
 <%--@elvariable id="url" type="org.jahia.services.render.URLGenerator"--%>
 
 <c:set var="moduleVersion" value="${script.view.moduleVersion}"/>
-<template:addResources type="javascript" resources="i18n/jcr-auth-provider-i18n_${renderContext.UILocale}.js?${moduleVersion}" var="i18nJSFile"/>
+<template:addResources type="javascript" resources="i18n/jcr-auth-provider-i18n_${renderContext.UILocale}.js" var="i18nJSFile"/>
 <c:if test="${empty i18nJSFile}">
-    <template:addResources type="javascript" resources="i18n/jcr-auth-provider-i18n_en.js?${moduleVersion}"/>
+    <template:addResources type="javascript" resources="i18n/jcr-auth-provider-i18n_en.js" var="i18nJSFile"/>
 </c:if>
-
 <template:addResources type="javascript" resources="jcr-auth-provider/jcr-mapper-controller.js"/>
+<template:addResources type="inline" targetTag="${renderContext.editMode?'head':'body'}">
+    <script type="text/javascript" src="${i18nJSFile}?${moduleVersion}"></script>
+</template:addResources>
 
 <md-card ng-controller="JCROAuthProviderController as jcrOAuthProvider" class="ng-cloak">
     <div layout="row">

--- a/src/main/resources/joant_jcrOAuthView/html/jcrOAuthView.jsp
+++ b/src/main/resources/joant_jcrOAuthView/html/jcrOAuthView.jsp
@@ -17,14 +17,15 @@
 <%--@elvariable id="url" type="org.jahia.services.render.URLGenerator"--%>
 
 <c:set var="moduleVersion" value="${script.view.moduleVersion}"/>
-<template:addResources type="javascript" resources="i18n/jcr-auth-provider-i18n_${renderContext.UILocale}.js" var="i18nJSFile"/>
+<template:addResources type="javascript" resources="i18n/jcr-auth-provider-i18n_${renderContext.UILocale}.js" key="${moduleVersion}" var="i18nJSFile"/>
 <c:if test="${empty i18nJSFile}">
-    <template:addResources type="javascript" resources="i18n/jcr-auth-provider-i18n_en.js" var="i18nJSFile"/>
+    <template:addResources type="javascript" resources="i18n/jcr-auth-provider-i18n_en.js" key="${moduleVersion}" var="i18nJSFile"/>
 </c:if>
 <template:addResources type="javascript" resources="jcr-auth-provider/jcr-mapper-controller.js"/>
-<template:addResources type="inline" targetTag="${renderContext.editMode?'head':'body'}">
-    <script type="text/javascript" src="${i18nJSFile}?${moduleVersion}"></script>
-</template:addResources>
+
+<%--<template:addResources type="inline" targetTag="${renderContext.editMode?'head':'body'}">--%>
+<%--    <script type="text/javascript" src="${i18nJSFile}?${moduleVersion}"></script>--%>
+<%--</template:addResources>--%>
 
 <md-card ng-controller="JCROAuthProviderController as jcrOAuthProvider" class="ng-cloak">
     <div layout="row">

--- a/src/main/resources/joant_jcrOAuthView/html/jcrOAuthView.jsp
+++ b/src/main/resources/joant_jcrOAuthView/html/jcrOAuthView.jsp
@@ -18,7 +18,7 @@
 
 <template:addResources type="javascript" resources="i18n/jcr-auth-provider-i18n_${renderContext.UILocale}.js" var="i18nJSFile"/>
 <c:if test="${empty i18nJSFile}">
-    <template:addResources type="javascript" resources="i18n/jcr-auth-provider-i18n_en.js" />
+    <template:addResources type="javascript" resources="i18n/jcr-auth-provider-i18n_en.js"/>
 </c:if>
 
 <template:addResources type="javascript" resources="jcr-auth-provider/jcr-mapper-controller.js"/>

--- a/src/main/resources/joant_jcrOAuthView/html/jcrOAuthView.jsp
+++ b/src/main/resources/joant_jcrOAuthView/html/jcrOAuthView.jsp
@@ -16,16 +16,12 @@
 <%--@elvariable id="currentResource" type="org.jahia.services.render.Resource"--%>
 <%--@elvariable id="url" type="org.jahia.services.render.URLGenerator"--%>
 
-<c:set var="moduleVersion" value="${script.view.moduleVersion}"/>
-<template:addResources type="javascript" resources="i18n/jcr-auth-provider-i18n_${renderContext.UILocale}.js" key="${moduleVersion}" var="i18nJSFile"/>
+<template:addResources type="javascript" resources="i18n/jcr-auth-provider-i18n_${renderContext.UILocale}.js" var="i18nJSFile"/>
 <c:if test="${empty i18nJSFile}">
-    <template:addResources type="javascript" resources="i18n/jcr-auth-provider-i18n_en.js" key="${moduleVersion}" var="i18nJSFile"/>
+    <template:addResources type="javascript" resources="i18n/jcr-auth-provider-i18n_en.js" />
 </c:if>
-<template:addResources type="javascript" resources="jcr-auth-provider/jcr-mapper-controller.js"/>
 
-<%--<template:addResources type="inline" targetTag="${renderContext.editMode?'head':'body'}">--%>
-<%--    <script type="text/javascript" src="${i18nJSFile}?${moduleVersion}"></script>--%>
-<%--</template:addResources>--%>
+<template:addResources type="javascript" resources="jcr-auth-provider/jcr-mapper-controller.js"/>
 
 <md-card ng-controller="JCROAuthProviderController as jcrOAuthProvider" class="ng-cloak">
     <div layout="row">


### PR DESCRIPTION
Closes https://github.com/Jahia/jcr-auth-provider/issues/84#issuecomment-4799002485
###
First attempt https://github.com/Jahia/jcr-auth-provider/pull/85 added `?${moduleVersion}` to the i18n resource URLs.
The new problem arose: `template:addResources` uses the resources attribute as a bundle file-path lookup. Any ? in the name is treated as part of the path, so the file is never found and no <script> tag is emitted. So i18nJSFile is always empty, the fallback also fails to load (for the same reason), and jcroai18n is never defined when the controller runs.
###
~~Proposed solution: load versioned i18n translations using pure js.~~

Finally, used `urlrewrite` rules to add unique identifier to i18n js files.

